### PR TITLE
feat: render Mermaid diagrams offline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "fs-extra": "^11.1.1",
         "mammoth": "^1.6.0",
         "marked": "^9.1.6",
-        "mermaid": "^10.6.1",
+        "mermaid": "^10.9.3",
         "mime-types": "^2.1.35",
         "ora": "^5.4.1",
         "puppeteer": "^21.5.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "fs-extra": "^11.1.1",
     "mammoth": "^1.6.0",
     "marked": "^9.1.6",
-    "mermaid": "^10.6.1",
+    "mermaid": "^10.9.3",
     "mime-types": "^2.1.35",
     "ora": "^5.4.1",
     "puppeteer": "^21.5.2",

--- a/src/processors/mermaid-png-processor.ts
+++ b/src/processors/mermaid-png-processor.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import sharp from 'sharp';
+import mermaid from 'mermaid';
 
 /**
  * Nouveau processeur Mermaid avec g??n??ration PNG compl??te
@@ -83,13 +84,16 @@ export class MermaidPNGProcessor {
     try {
       const page = await this.browser.newPage();
       await page.setViewport({ width: 1200, height: 800 });
+      await page.setOfflineMode(true);
 
-      // HTML pour rendre le diagramme Mermaid
+      const mermaidPath = require.resolve('mermaid/dist/mermaid.min.js');
+
+      // HTML pour rendre le diagramme Mermaid avec le script local
       const html = `
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="https://cdn.jsdelivr.net/npm/mermaid@10.6.1/dist/mermaid.min.js"></script>
+    <script src="file://${mermaidPath}"></script>
     <style>
         body {
             margin: 0;
@@ -110,7 +114,7 @@ ${diagramCode}
         mermaid.initialize({
             startOnLoad: true,
             theme: 'default',
-            securityLevel: 'loose',
+            securityLevel: 'strict',
             flowchart: {
                 htmlLabels: true,
                 curve: 'basis'
@@ -170,7 +174,7 @@ ${diagramCode}
     if (!this.browser) {
       this.browser = await puppeteer.launch({
         headless: 'new',
-        args: ['--no-sandbox', '--disable-setuid-sandbox']
+        args: ['--no-sandbox', '--disable-setuid-sandbox', '--allow-file-access-from-files']
       });
     }
   }

--- a/tests/mermaid-offline.test.ts
+++ b/tests/mermaid-offline.test.ts
@@ -1,0 +1,17 @@
+import { MermaidPNGProcessor } from '../src/processors/mermaid-png-processor';
+
+describe('MermaidPNGProcessor Offline Rendering', () => {
+  test('renders diagram without network access', async () => {
+    const processor = new MermaidPNGProcessor();
+    const markdown = '```mermaid\ngraph LR\nA-->B\n```';
+
+    const result = await processor.processContent(markdown);
+
+    expect(result.diagramCount).toBe(1);
+    expect(result.images.length).toBe(1);
+    expect(result.images[0].buffer.length).toBeGreaterThan(0);
+
+    await processor.cleanup();
+    processor.cleanupTempDir();
+  });
+});


### PR DESCRIPTION
## Summary
- load Mermaid from local dependency and initialize with strict security
- update HTML template and puppeteer settings for offline rendering
- add test ensuring Mermaid PNG generation works without network

## Testing
- `npm test` *(fails: Failed to launch the browser process: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68962502c82483228a0c2f2ff4d28a30